### PR TITLE
Use escaped ASCII for unicode filename on python2

### DIFF
--- a/libxmp/files.py
+++ b/libxmp/files.py
@@ -41,6 +41,7 @@ efficiently access the XMP in specific file formats. It also includes a
 fallback packet scanner that can be used for unknown file formats.
 """
 import os
+import sys
 
 from . import XMPError, XMPMeta
 from .consts import options_mask
@@ -79,15 +80,25 @@ class XMPFiles(object):
 
             self.open_file( file_path, **kwargs )
 
-
     def __repr__(self):
-        msg = "XMPFiles("
         if self._file_path is None:
-            msg += ")"
+            return "XMPFiles()"
+
+        msg = "XMPFiles(file_path='{0}')"
+        if sys.hexversion < 0x03000000 and isinstance(self._file_path,
+                                                      unicode):
+            # Unicode filenames can cause trouble in python2 because __repr__
+            # must return byte strings, not unicode. Get around this by
+            # turning the unicode filename into escaped ASCII.  This means that
+            # in this case, the result cannot be used to recreate the object
+            # with the same value.
+            msg = msg.format(repr(self._file_path))
         else:
-            msg += "file_path='{0}')"
+            # Python3 does not suffer from this problem.
             msg = msg.format(self._file_path)
+
         return msg
+
     def __del__(self):
         """
         Free up the memory associated with the XMP file instance.


### PR DESCRIPTION
__repr__ with unicode is problematic in python2.

Interpolating a unicode filename into an ASCII string as previously
done  resulted in a UnicodeEncodeError.  We cannot interpolate a
unicode filename into a unicode string as the __repr__ function
must return a byte string in python2.  Since __repr__ does not
absolutely have to return a byte string that can always be used to
recreate the object, we just use REPR on the unicode filename under
python2, which results in escaped ASCII.

We cannot simply use repr(filename) for all cases, since it does change
the output in python3, changes something that isn't broken, and breaks
two existing tests anyway.

In python3 the issue doesn't arise since __repr__ and __str__ return
unicode instead of byte strings.

Closes-Issue:  #36