### PR TITLE
Update Cygwin, macports issues in doc

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -39,11 +39,13 @@ systems package manager, e.g.::
 
     sudo apt-get install libexempi3  # (Ubuntu/Debian)
     brew install exempi  # (Homebrew on OS X)
+    port install exempi  # (MacPorts)
 
 Mac OS X
 --------
 Note Exempi requires boost (http://www.boost.org/) to compile, so on OS
-X you probably need to run configure with one of the following options::
+X (without Homebrew or MacPorts) you probably need to run configure
+with one of the following options::
 
   ./configure --with-boost=/usr/local # (for Homebrew)
   ./configure --with-darwinports
@@ -55,5 +57,4 @@ The library has not been tested on Windows, and nor has any serious effort
 been made to test it. Hence, developers wanting to use the library on Windows
 are encouraged to try it out and let us know if it works.
 
-The library ought to work on Windows, if Exempi can be compiled as a DLL using
-e.g. Cygwin.
+The library does work on recent versions of Cygwin.

--- a/docs/appendix.rst
+++ b/docs/appendix.rst
@@ -3,11 +3,12 @@ Appendix
 
 Known Issues
 ------------
- * The version of libexempi that comes via Macports refuses to load via ctypes.
-   As a workaround, you should compile libexempi from source.
  * The exempi library can add XMP to PDF files that already have an XMP packet
    but cannot inject XMP into PDFs that do not; therefore, neither can the
    Python XMP Toolkit. 
+ * The exempi library routines "xmp_files_check_file_format" and
+   "files_get_file_info" are not available on Cygwin.  This does not affect
+   the functionality of the high-level XMPMeta or XMPFiles objects.
 
 Resources
 ---------

--- a/test/test_exempi.py
+++ b/test/test_exempi.py
@@ -39,7 +39,7 @@ from libxmp.consts import XMP_PROP_HAS_QUALIFIERS, XMP_PROP_IS_QUALIFIER
 from libxmp.consts import XMP_PROP_COMPOSITE_MASK
 
 CYGWIN_PLATFORM = sys.platform == 'cygwin'
-CYGWIN_MSG = "blah"
+CYGWIN_MSG = "functionality not available on cygwin"
 
 
 class TestInit(unittest.TestCase):


### PR DESCRIPTION
The macports issue was fixed upstream by the exempi port maintainer.

Make it clear that the Mac OS X installation instructions are not
meant for Homebrew or MacPorts users.

Cygwin mostly works as a platform, had been under the impression that
it did not.  Change the documentation to reflect what works and what
does not.

"files_check_file_format" and "files_get_file_info" are the two exempi
library functions that do not seem to be present in the Cygwin version
of the library.

Skip the one test that absolutely cannot run on Cygwin.  Two others can
run certain portions on Cygwin, so they are not completely filtered out.

Some tests were checking the file format of BlueSquare.jpg, which will
fail on Cygwin.  Since that specific test is done in
test.test_exempi.TestSuite.test_formats, those checks can be removed.

Two tests added to nail down Cygwin behavior.

Closes-Issue: #6
Closes-Issue: #41