### PR TITLE
Add error checking on files_get_new_xmp

### DIFF
--- a/libxmp/exempi.py
+++ b/libxmp/exempi.py
@@ -55,7 +55,7 @@ def _load_exempi():
             if os.path.exists('/opt/local/lib/libexempi.dylib'):
                 # MacPorts starndard location.
                 path = '/opt/local/lib/libexempi.dylib'
-            
+
     if path is None:
         raise ExempiLoadError('Exempi library not found.')
 
@@ -402,9 +402,18 @@ def files_get_new_xmp(xfptr):
     xmp_ptr : ctypes pointer
         XMP pointer
     """
-    EXEMPI.xmp_files_get_new_xmp.restype = check_error
+    EXEMPI.xmp_files_get_new_xmp.restype = ctypes.c_void_p
     EXEMPI.xmp_files_get_new_xmp.argtypes = [ctypes.c_void_p]
     xmp_ptr = EXEMPI.xmp_files_get_new_xmp(xfptr)
+
+    ecode = get_error()
+    if ecode != 0:
+        import ipdb
+        ipdb.set_trace()
+        error_msg = ERROR_MESSAGE[ecode]
+        msg = 'Exempi function failure ("{0}").'.format(error_msg)
+        raise XMPError(msg)
+
     return xmp_ptr
 
 

--- a/libxmp/exempi.py
+++ b/libxmp/exempi.py
@@ -402,7 +402,7 @@ def files_get_new_xmp(xfptr):
     xmp_ptr : ctypes pointer
         XMP pointer
     """
-    EXEMPI.xmp_files_get_new_xmp.restype = ctypes.c_void_p
+    EXEMPI.xmp_files_get_new_xmp.restype = check_error
     EXEMPI.xmp_files_get_new_xmp.argtypes = [ctypes.c_void_p]
     xmp_ptr = EXEMPI.xmp_files_get_new_xmp(xfptr)
     return xmp_ptr

--- a/libxmp/exempi.py
+++ b/libxmp/exempi.py
@@ -408,8 +408,6 @@ def files_get_new_xmp(xfptr):
 
     ecode = get_error()
     if ecode != 0:
-        import ipdb
-        ipdb.set_trace()
         error_msg = ERROR_MESSAGE[ecode]
         msg = 'Exempi function failure ("{0}").'.format(error_msg)
         raise XMPError(msg)

--- a/test/test_roundtrip.py
+++ b/test/test_roundtrip.py
@@ -61,7 +61,7 @@ class TestRoundTrip(unittest.TestCase):
                                                   "fixtures/zeros.tif")
         with tempfile.NamedTemporaryFile(suffix='.tif') as tfile:
             shutil.copyfile(srcfile, tfile.name)
- 
+
             expected_value = u'Stürm und Drang'
 
             xmpf = XMPFiles()
@@ -76,7 +76,7 @@ class TestRoundTrip(unittest.TestCase):
             xmp = xmpf.get_xmp()
             actual_value = xmp.get_property(NS_DC, "Title")
             xmpf.close_file()
-            
+
             self.assertEqual(actual_value, expected_value)
 
 
@@ -88,7 +88,7 @@ class TestRoundTrip(unittest.TestCase):
         with tempfile.NamedTemporaryFile(suffix='.tif', mode='wb') as tfile:
 
             # Do some surgery on the file, remove existing xmp.
-            # The APP1 marker segment in question starts at byte 2156, has 
+            # The APP1 marker segment in question starts at byte 2156, has
             # length of 4813
             with open(srcfile, 'rb') as infptr:
 
@@ -99,7 +99,6 @@ class TestRoundTrip(unittest.TestCase):
                 infptr.seek(21619)
                 tfile.write(infptr.read())
                 tfile.flush()
-
 
             xmpf = XMPFiles()
             xmpf.open_file(file_path=tfile.name, open_forupdate=True)


### PR DESCRIPTION
When calling `XMPFiles.get_xmp` on a file with badly-formatted XMP, `files_get_new_xmp` does not check the return code sent by exempi (-201 in my own case), which causes no XMPError exception to be raised in the Python environment.

I do not know if there's a specific reason as to why the check_error callback is not used in `files_get_new_xmp` when it is in several other methods, but if there isn't, here is the small modification that allows Python code to catch and handle the error.