### PR TITLE
Add error checking on files_get_new_xmp (devel branch)

### DIFF
--- a/libxmp/exempi.py
+++ b/libxmp/exempi.py
@@ -439,6 +439,13 @@ def files_get_new_xmp(xfptr):
     EXEMPI.xmp_files_get_new_xmp.restype = ctypes.c_void_p
     EXEMPI.xmp_files_get_new_xmp.argtypes = [ctypes.c_void_p]
     xmp_ptr = EXEMPI.xmp_files_get_new_xmp(xfptr)
+
+    ecode = get_error()
+    if ecode != 0:
+        error_msg = ERROR_MESSAGE[ecode]
+        msg = 'Exempi function failure ("{0}").'.format(error_msg)
+        raise XMPError(msg)
+
     return xmp_ptr
 
 


### PR DESCRIPTION
Here's the same modification as #59 but on the devel branch.

You can find below a TIFF file with badly formatted metadata (a closing tag is missing) that causes exempi to return an error when calling `get_xmp`:
[badlyFormattedMetadata.zip](https://github.com/python-xmp-toolkit/python-xmp-toolkit/files/311486/badlyFormattedMetadata.zip)
