### PR TITLE
Remove mention of MacPorts ctypes issue

### DIFF
--- a/docs/appendix.rst
+++ b/docs/appendix.rst
@@ -1,11 +1,6 @@
 Appendix
 ========
 
-Known Issues
-------------
- * The version of libexempi that comes via Macports refuses to load via ctypes.
-   As a workaround, you should compile libexempi from source.
-
 Resources
 ---------
  * Project website -- https://github.com/python-xmp-toolkit/python-xmp-toolkit


### PR DESCRIPTION
The fact that MacPorts exempi was incompatible with the
python-xmp-toolkit has not been the case for some time now.

Remove comment about this from the docs.

Closes-Issue: #6