### PR TITLE
Add missing error codes and graceful handling of possible future codes

### DIFF
--- a/libxmp/exempi.py
+++ b/libxmp/exempi.py
@@ -85,6 +85,7 @@ ERROR_MESSAGE = {    0: "unknown error",
                    -13: "std exception",
                    -14: "unknown exception",
                    -15: "no memory",
+                   -16: "progress abort",
                   -101: "bad schema",
                   -102: "bad XPath",
                   -103: "bad options",
@@ -95,6 +96,14 @@ ERROR_MESSAGE = {    0: "unknown error",
                   -108: "bad file format",
                   -109: "no file handler",
                   -110: "too large for JPEG",
+                  -111: "no file",
+                  -112: "file permission error",
+                  -113: "disk space",
+                  -114: "read error",
+                  -115: "write error",
+                  -116: "bad block format",
+                  -117: "file path not a file",
+                  -118: "rejected file extension",
                   -201: "bad XML",
                   -202: "bad RDF",
                   -203: "bad XMP",
@@ -1697,6 +1706,9 @@ def check_error(success):
     # so we supplement it by explicitly checking the error code.
     ecode = EXEMPI.xmp_get_error()
     if not success or ecode != 0:
-        error_msg = ERROR_MESSAGE[ecode]
+        if ecode in ERROR_MESSAGE:
+            error_msg = ERROR_MESSAGE[ecode]
+        else:
+            error_msg = "Unexpected error code " + str(ecode)
         msg = 'Exempi function failure ("{0}").'.format(error_msg)
         raise XMPError(msg)


### PR DESCRIPTION
If a unknown error code is returned then a less then helpful key error is thrown when the lookup for the error string is being done. This patch adds the current missing codes and a method of raising an error with higher utility.

Codes gathered from the exempi documentation: https://gitlab.freedesktop.org/libopenraw/exempi/-/blob/master/docs/API/XMP__Const_8h.html