### PR TITLE
Make Exempi run-time dependency

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -19,9 +19,6 @@ or if you use pip::
 
   pip install python-xmp-toolkit
 
-Note, in case you haven't installed Exempi you will get an
-:exc:`ExempiLoadError` exception once you try to load :mod:`libxmp`.
-
 Exempi
 ------
 Python XMP Toolkit requires Exempi 2.2.0 or higher which can be downloaded from

--- a/libxmp/__init__.py
+++ b/libxmp/__init__.py
@@ -57,4 +57,3 @@ __all__ = ['XMPMeta', 'XMPFiles', 'XMPError', 'ExempiLoadError', 'files',
            'core']
 
 from . import exempi
-exempi.init()

--- a/libxmp/exempi.py
+++ b/libxmp/exempi.py
@@ -69,7 +69,27 @@ def _load_exempi():
 
     return EXEMPI
 
-EXEMPI = _load_exempi()
+
+class LazyExempi:
+    """Wrapper for ctypes library making it loaded on actual first use.
+    """
+    def __init__(self):
+        self._exempi = None
+
+    def __getattr__(self, attr):
+        if self._exempi is None:
+            self._exempi = _load_exempi()
+            init()
+        return getattr(self._exempi, attr)
+
+    def __setattr__(self, attr, value):
+        if attr == "_exempi":
+            self.__dict__[attr] = value
+        else:
+            return setattr(self._exempi, attr, value)
+
+
+EXEMPI = LazyExempi()
 
 # Error codes defined by libexempi.  See "xmperrors.h"
 ERROR_MESSAGE = {    0: "unknown error",


### PR DESCRIPTION
Corresponding to the #97
Before Exempt was a required dependency for the installation of the xml-toolkit. No it's not.
Also fixes this #88 (tested myself)